### PR TITLE
Update regine

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,6 +2,6 @@
            {parse_transform, lager_transform}]}.
 
 {deps, [
-        {regine, ".*", {git, "git://github.com/travelping/regine.git", "0.2.0"}},
-        {lager, ".*", {git, "git://github.com/basho/lager", "2.1.1"}}
+        {lager, ".*", {git, "git://github.com/basho/lager", "2.1.1"}},
+        {regine, ".*", {git, "git://github.com/travelping/regine.git", "0.2.1"}}
 ]}.


### PR DESCRIPTION
- regine 0.2.1 has compatibility with erl 18
- placed lager to the first position in rebar.config for correct using parse_transform
